### PR TITLE
remove attempted fix to speed up queries

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -28,12 +28,10 @@ class User extends Model {
             }],
             required: true,
             where: groupedSearch.milestone,
-            separate: true
           },
           {
             model: ProjectFieldEntry,
-            include: ProjectField,
-            separate: true
+            include: ProjectField
           },
           {
             required: true,


### PR DESCRIPTION
Revert change in an attempt to speed up database requests. This was causing a bug whereby filters were not working correctly.