### PR TITLE
reset contentHTML so milestones from previous projects dont show in drop down

### DIFF
--- a/pages/all-data/AllData.html
+++ b/pages/all-data/AllData.html
@@ -176,6 +176,8 @@
 
   {% set projectFields = (projectFields.push(projectValue), projectFields) %}
 
+  {% set contentHtml %}{% endset  %}
+
   {% for milestone in project.milestones %}
     {% set milestoneValue = [] %}
 


### PR DESCRIPTION
…rop down

If project does not have any milestones, milestones from the previous project are showing in drop down in the all-data page
