### PR TITLE
Restrict reporting overview

### DIFF
--- a/common/views/navigation.njk
+++ b/common/views/navigation.njk
@@ -26,11 +26,13 @@
         </a>
     </li>
     {% endif %}
+    {% if req.user.hasViewAllPermissions %}
     <li class="govuk-header__navigation-item {% if (url == config.paths.reportingOverview) %} govuk-header__navigation-item--active {% endif %}">
         <a class="govuk-header__link nav" href="{{ config.paths.reportingOverview }}">
         Reporting overview
         </a>
     </li>
+    {% endif %}
     </ul>
 </nav>
 

--- a/models/user.js
+++ b/models/user.js
@@ -140,6 +140,10 @@ class User extends Model {
       milestone: projects[0].milestones[0]
     };
   }
+
+  get hasViewAllPermissions() {
+    return this.departments.length > 1;
+  }
 }
 
 User.init({

--- a/pages/page-not-found/PageNotFound.js
+++ b/pages/page-not-found/PageNotFound.js
@@ -2,6 +2,10 @@ const Page = require('core/pages/page');
 const { Router } = require('express');
 
 class PageNotFound extends Page {
+  static get isEnabled() {
+    return false;
+  }
+
   // page-not-found page does not require user authentication
   get middleware() {
     return [];

--- a/pages/page-not-found/PageNotFound.js
+++ b/pages/page-not-found/PageNotFound.js
@@ -2,6 +2,8 @@ const Page = require('core/pages/page');
 const { Router } = require('express');
 
 class PageNotFound extends Page {
+  // do not attach pageNotFound to the global router or all pages will redirect to it
+  // this page is manually added in app.js
   static get isEnabled() {
     return false;
   }

--- a/test/unit/models/user.test.js
+++ b/test/unit/models/user.test.js
@@ -37,15 +37,27 @@ describe('models/user', () => {
         field: "must_change_password"
       }
     });
+  });
 
-    it('called User.belongsToMany with the correct parameters', () => {
-      expect(User.belongsToMany).to.have.been.calledWith(Department, { through: DepartmentUser, foreignKey: 'userId' });
+  it('called User.belongsToMany with the correct parameters', () => {
+    expect(User.belongsToMany).to.have.been.calledWith(Department, { through: DepartmentUser, foreignKey: 'userId' });
+  });
+
+  it('called Department.belongsToMany with the correct parameters', () => {
+    expect(Department.belongsToMany).to.have.been.calledWith(User, { through: DepartmentUser, foreignKey: 'departmentName' });
+  });
+
+  describe('#hasViewAllPermissions', () => {
+    it('returns true if user can view more than one department', () => {
+      const user = new User();
+      user.departments = [{}, {}];
+      expect(user.hasViewAllPermissions).to.be.ok;
     });
 
-    it('called Department.belongsToMany with the correct parameters', () => {
-      expect(Department.belongsToMany).to.have.been.calledWith(User, { through: DepartmentUser, foreignKey: 'departmentName' });
-    });
-
-    it.skip('#getProjects');
+    it('returns false if user can only view one department', () => {
+      const user = new User();
+      user.departments = [{}];
+      expect(user.hasViewAllPermissions).to.not.be.ok;
+    })
   });
 });

--- a/test/unit/pages/index.test.js
+++ b/test/unit/pages/index.test.js
@@ -11,10 +11,15 @@ describe('Pages', () => {
       missedMilestones: true
     });
 
-    const allPageNames = []
+    const allPageNames = [];
+    const allPageNamesToNotAdd = [];
     glob.sync('./pages/**/*.js', { "ignore":['./pages/index.js'] }).forEach(file => {
       const Page = require(path.resolve(file));
-      allPageNames.push(new Page().constructor.name);
+      if (Page.isEnabled) {
+        allPageNames.push(new Page().constructor.name);
+      } else {
+        allPageNamesToNotAdd.push(new Page().constructor.name);
+      }
     });
 
     const pagesAttached = [];
@@ -23,6 +28,7 @@ describe('Pages', () => {
     pages.attach({ use });
 
     allPageNames.forEach(name => expect(pagesAttached).to.include(name));
+    allPageNamesToNotAdd.forEach(name => expect(pagesAttached).to.not.include(name));
 
     sandbox.restore();
   });


### PR DESCRIPTION
- do not attach pageNotFound to the global router or all pages will redirect to it
- restrict reporting overview to users who can see more than one department