### PR TITLE
Readiness outcome integration - session storage

### DIFF
--- a/common/javascript/main.js
+++ b/common/javascript/main.js
@@ -29,4 +29,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 // The expanded state of individual instances of the accordion component persists across page loads using sessionStorage.
 // These will be removed from the session storage so the accordions will collapse rather than stay open.
-sessionStorage.clear();
+// We want to keep session storage on the readiness theme pages to prevent accordions closing on a page refresh 
+if (!window.location.pathname.includes('/transition-readiness-detail/')) {
+  sessionStorage.clear();
+}

--- a/common/javascript/readiness-accordion.js
+++ b/common/javascript/readiness-accordion.js
@@ -85,7 +85,7 @@ ReadinessAccordion.prototype.isExpanded = function (section) {
 }
 
 // Check for `window.sessionStorage`, and that it actually works.
-var helper = {
+const helper = {
   checkForSessionStorage: function () {
     const testString = 'this is the test string'
     let result
@@ -105,9 +105,6 @@ var helper = {
 // Set the state of the accordions in sessionStorage
 ReadinessAccordion.prototype.storeState = function (section) {
   if (this.browserSupportsSessionStorage) {
-    // We need a unique way of identifying each content in the accordion. Since
-    // an `#id` should be unique and an `id` is required for `aria-` attributes
-    // `id` can be safely used.
     const button = section.querySelector('.' + this.sectionButtonClass)
 
     if (button) {

--- a/common/javascript/readiness-accordion.js
+++ b/common/javascript/readiness-accordion.js
@@ -20,6 +20,7 @@ function ReadinessAccordion ($module) {
   this.moduleId = $module.getAttribute('id')
   this.$sections = $module.querySelectorAll(`.govuk-accordion__section-${this.moduleId }`)
   this.$openAllButton = ''
+  this.browserSupportsSessionStorage = helper.checkForSessionStorage()
 
   this.controlsClass = 'govuk-accordion__controls'
   this.openAllClass = 'govuk-accordion__open-all'
@@ -55,6 +56,7 @@ ReadinessAccordion.prototype.initSectionHeaders = function () {
     // Handle events
     header.addEventListener('click', this.onSectionToggle.bind(this, section))
 
+    this.setInitialState(section)
   }.bind(this))
 }
 
@@ -62,6 +64,7 @@ ReadinessAccordion.prototype.initSectionHeaders = function () {
 ReadinessAccordion.prototype.onSectionToggle = function (section) {
   const expanded = this.isExpanded(section)
   this.setExpanded(!expanded, section)
+  this.storeState(section)
 }
 
 // Set section attributes when opened/closed
@@ -81,5 +84,67 @@ ReadinessAccordion.prototype.isExpanded = function (section) {
   return section.classList.contains(this.sectionExpandedClass)
 }
 
+// Check for `window.sessionStorage`, and that it actually works.
+var helper = {
+  checkForSessionStorage: function () {
+    const testString = 'this is the test string'
+    let result
+    try {
+      window.sessionStorage.setItem(testString, testString)
+      result = window.sessionStorage.getItem(testString) === testString.toString()
+      window.sessionStorage.removeItem(testString)
+      return result
+    } catch (exception) {
+      if (typeof console === 'undefined') {
+        new Error('Notice: sessionStorage not available.')
+      }
+    }
+  }
+}
+
+// Set the state of the accordions in sessionStorage
+ReadinessAccordion.prototype.storeState = function (section) {
+  if (this.browserSupportsSessionStorage) {
+    // We need a unique way of identifying each content in the accordion. Since
+    // an `#id` should be unique and an `id` is required for `aria-` attributes
+    // `id` can be safely used.
+    const button = section.querySelector('.' + this.sectionButtonClass)
+
+    if (button) {
+      const contentId = button.getAttribute('aria-controls')
+      const contentState = button.getAttribute('aria-expanded')
+
+      if (typeof contentId === 'undefined') {
+        new Error('No aria controls present in accordion section heading.')
+      }
+
+      if (typeof contentState === 'undefined') {
+        new Error('No aria expanded present in accordion section heading.')
+      }
+
+      // Only set the state when both `contentId` and `contentState` are taken from the DOM.
+      if (contentId && contentState) {
+        window.sessionStorage.setItem(contentId, contentState)
+      }
+    }
+  }
+}
+
+// Read the state of the accordions from sessionStorage
+ReadinessAccordion.prototype.setInitialState = function (section) {
+  if (this.browserSupportsSessionStorage) {
+    const button = section.querySelector('.' + this.sectionButtonClass)
+
+    if (button) {
+      const contentId = button.getAttribute('aria-controls')
+      
+      let contentState = contentId ? window.sessionStorage.getItem(contentId) : null
+
+      if (contentState !== null) {
+        this.setExpanded(contentState === 'true', section)
+      }
+    }
+  }
+}
 
 export default ReadinessAccordion

--- a/common/macros/readiness-accordion.njk
+++ b/common/macros/readiness-accordion.njk
@@ -16,7 +16,7 @@
           <div class="govuk-accordion__section-header section-header-{{ item.level }}">
             <h2 class="govuk-accordion__section-heading govuk-heading-s">
 
-              <button type="button" id="accordion-default-{{ id }}-heading-{{ id }}" aria-controls="accordion-default-{{ id }}-content-{{ id }}" class="govuk-accordion__section-button" aria-expanded="{{ expanded }}">
+              <button type="button" id="accordion-default-{{ id }}-heading-{{ loop.index }}" aria-controls="accordion-default-{{ id }}-content-{{ loop.index }}" class="govuk-accordion__section-button" aria-expanded="{{ expanded }}">
                 {{ heading }}
                 {% if item.level > 1 %} ({{ childCount }}){% endif %}
                 <span class="govuk-accordion__icon" aria-hidden="true"></span>
@@ -48,12 +48,12 @@
   </ul>
 {% endmacro %}
 
-{% macro buildOutcomeMeasures(items, level) %}
+{% macro buildOutcomeMeasures(items, level, statement) %}
   {% set outcomeMeasuresData = [] %}
 
   {% for item in items %}
     {% if (item.children | length >= 1) and not item.isLastExpandable %}
-        {% set htmlContent = buildOutcomeMeasures(item.children, level + 1) %}
+        {% set htmlContent = buildOutcomeMeasures(item.children, level + 1, statement) %}
     {% elif item.children | length >= 1 and item.isLastExpandable %}
         {% set htmlContent = outcomeMeasuresContent(item.children) %}
     {% else %}
@@ -67,7 +67,7 @@
   {% endfor %}
 
   {{ accordion({
-    id: 'accordion-default-' + level,
+    id: statement +'-accordion-' + level,
     classes: 'accordion-level-' + level,
     items: outcomeMeasuresData
   }) }}

--- a/pages/theme/Theme.html
+++ b/pages/theme/Theme.html
@@ -25,7 +25,7 @@
   <div class="govuk-grid-column-one-quarter no-horizontal-padding top-statements">
     {% if data.subOutcomeStatementsAndDatas | length > 0%}
       <div class="readiness-accordion-wrapper" >
-        {{ buildOutcomeMeasures(data.subOutcomeStatementsAndDatas, 1) }}
+        {{ buildOutcomeMeasures(data.subOutcomeStatementsAndDatas, 1, req.params.statement) }}
       </div>
     {% else %}
       <h2 class="govuk-heading-s measures-message">To view data, select an outcome statement</h4>


### PR DESCRIPTION
Added in session storage for the readiness accordions to prevent them from closing when the page refreshes.

Session storage will be cleared when on any other pages, as per previous behaviour.