### PR TITLE
landing page change

### DIFF
--- a/pages/start/Start.js
+++ b/pages/start/Start.js
@@ -16,7 +16,7 @@ class Start extends Page {
       return res.redirect(config.paths.readinessOverview);
     }
 
-    return res.redirect(config.paths.reportingOverview);
+    return res.redirect(config.paths.allData);
   }
 }
 

--- a/test/unit/pages/Start.test.js
+++ b/test/unit/pages/Start.test.js
@@ -27,10 +27,10 @@ describe('pages/start/Start', () => {
       sinon.assert.calledWith(res.redirect, config.paths.authentication.passwordReset);
     });
 
-    it('redirects to reporting overview landing page if it does not have viewer role', async() => {
-      req.user.roles = [{ name: 'management_overview' }];
+    it('redirects to all data landing page if it does not have viewer role', async() => {
+      req.user.roles = [{ name: 'management' }];
       await page.handler(req, res);
-      sinon.assert.calledWith(res.redirect, config.paths.reportingOverview);
+      sinon.assert.calledWith(res.redirect, config.paths.allData);
     });
 
     it('redirects to readiness overview landing page if it has viewer role', async() => {


### PR DESCRIPTION
Requirement changes

Users will be redirected to the Readiness Overview page upon login
If they do not have the ‘viewer’ role to view that page, they will be redirected to the All Data page
This means they will need to have either or both of ‘management’ and ‘viewer’ roles