### PR TITLE
DDB 989 - Measure information - Update RAYG values for single value groups

### DIFF
--- a/common/macros/data-entry-content.njk
+++ b/common/macros/data-entry-content.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 
-{% macro dataEntriesContent(groupMeasures, url, metricId, data, formFields) %}
+{% macro dataEntriesContent(groupMeasures, url, data, formFields) %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
@@ -37,7 +37,7 @@
 
   <p class="govuk-body govuk-!-font-weight-bold">Add a new value<p>
   <div class="data-entry">
-    <form action="{{ url }}/{{ metricId }}/add" method="post">
+    <form action="{{ url }}" method="post">
       <input type="hidden" name="type" value="entries" />
 
       {{ govukDateInput({

--- a/common/macros/measure-information.njk
+++ b/common/macros/measure-information.njk
@@ -1,5 +1,5 @@
-{% macro measureInformation(measure, url, metricId, data) %}
-  <form action="{{ url }}/{{ metricId }}/edit#measure-information" method="post">
+{% macro measureInformation(measure, url, data, uniqMetricIds, raygValue) %}
+  <form action="{{ url }}#measure-information" method="post">
 
     <div class="govuk-form-group">
       <label class="govuk-label govuk-!-font-weight-bold" for="entity-description">Description</label>
@@ -32,6 +32,19 @@
         <input class="govuk-input govuk-input--width-2" type="text" id="entity-greenThreshold" name="greenThreshold" value="{{ data.greenThreshold | default(measure.greenThreshold) }}" />
       </div>
     </div>
+
+    {% if uniqMetricIds | length === 1 %}
+      {% set groupValue = data.groupValue | default(raygValue) %}
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="groupValue">Overall RAYG value</label>
+        <select class="govuk-select" id="groupValue" name="groupValue">
+          <option value="1" {{ "selected" if groupValue == 1 }} >Red</option>
+          <option value="2" {{ "selected" if groupValue == 2 }} >Amber</option>
+          <option value="3" {{ "selected" if groupValue == 3 }} >Yellow</option>
+          <option value="4" {{ "selected" if groupValue == 4 }} >Green</option>
+        </select>
+      </div>
+    {% endif %}
 
     <br>
     <button class="govuk-button" data-module="govuk-button" type="submit">Save</button>

--- a/pages/data-entry-entity/measure-edit/MeasureEdit.html
+++ b/pages/data-entry-entity/measure-edit/MeasureEdit.html
@@ -26,6 +26,8 @@
 {% set latestMeasure = measure.latest %}
 {% set groupedMeasures = measure.grouped %}
 {% set formFields = measure.fields %}
+{% set uniqMetricIds = measure.uniqMetricIds %}
+{% set raygValue = measure.raygValue %}
 {% set errorMessages = errors if errors else flash %}
 
 {% block content %}

--- a/pages/data-entry-entity/measure-edit/partials/forms.njk
+++ b/pages/data-entry-entity/measure-edit/partials/forms.njk
@@ -23,14 +23,14 @@
       label: "Data entries",
       id: "data-entries",
       panel: {
-        html: dataEntriesContent(groupedMeasures, url, req.params.metricId, data, formFields)
+        html: dataEntriesContent(groupedMeasures, addUrl, data, formFields)
       }
     },
     {
       label: "Measure information",
       id: "measure-information",
       panel: {
-        html: measureInformation(latestMeasure, url, req.params.metricId, postData)
+        html: measureInformation(latestMeasure, editUrl, postData, uniqMetricIds, raygValue)
       }
     }
   ]

--- a/pages/data-entry-entity/measure-list/MeasureList.html
+++ b/pages/data-entry-entity/measure-list/MeasureList.html
@@ -68,7 +68,7 @@
                 <td class="govuk-table__cell">{{ "Yes" if measure.commentsOnly else "No" }}</td>
                 <td class="govuk-table__cell">{{ measure.date }}</td>
                 <td class="govuk-table__cell govuk-table__cell__actions">
-                  <a href="{{ config.paths.dataEntryEntity.measureEdit }}/{{ measure.metricID }}" class="govuk-link">Edit</a>
+                  <a href="{{ config.paths.dataEntryEntity.measureEdit }}/{{ measure.metricID }}/{{ measure.groupID }}" class="govuk-link">Edit</a>
                 </td>
               </tr>
             {% endfor %}
@@ -125,7 +125,7 @@
               <td class="govuk-table__cell">{{ "Yes" if measure.commentsOnly else "No" }}</td>
               <td class="govuk-table__cell">{{ measure.date }}</td>
               <td class="govuk-table__cell govuk-table__cell__actions">
-                <a href="{{ config.paths.dataEntryEntity.measureEdit }}/{{ measure.metricID }}" class="govuk-link">Edit</a>
+                <a href="{{ config.paths.dataEntryEntity.measureEdit }}/{{ measure.metricID }}/{{ measure.groupID }}" class="govuk-link">Edit</a>
               </td>
             </tr>
           {% endfor %}


### PR DESCRIPTION
Gets all measures within a group and filters to get individual metric data

Below changes apply when a measure is the only measure within the group

Added dropdown to set overall RAYG value (for the RAYG row)
Updates all RAYG thresholds for all measure entities (apart from RAYG row)