### PR TITLE
Measure update value - fix for when latest date is updated

### DIFF
--- a/pages/data-entry-entity/measure-value/MeasureValue.js
+++ b/pages/data-entry-entity/measure-value/MeasureValue.js
@@ -132,13 +132,13 @@ class MeasureValue extends Page {
 
     if (isOnlyMeasureInGroup && doesNotHaveFilter) {
       let { value } = newEntities[0];
-      let LatestEntryUpdate = false;
+      let latestEntryUpdate = false;
 
       // If the latest meausevalue was updated, the date could have been changed to a point in the past.
       // To find the correct value for the RAYG row, we need to combined the submited form datawith the 
       // current measure values and re-sort by date, this will give us the correct entry and value
       if (latestEntry.publicId === newEntities[0].publicId) {
-        LatestEntryUpdate = true;
+        latestEntryUpdate = true;
 
         const measureEntitiesCloned = cloneDeep(measureEntities);
         const clonedLatestEntry = measureEntitiesCloned[measureEntitiesCloned.length -1];
@@ -153,7 +153,7 @@ class MeasureValue extends Page {
         newDate = moment(latestEntryAfterSorting.date, 'DD/MM/YYYY').format('YYYY-MM-DD');
       }
 
-      if (isDateLatestOrNewer || updateRAYG == 'true' || LatestEntryUpdate) {
+      if (isDateLatestOrNewer || updateRAYG == 'true' || latestEntryUpdate) {
        
         // We need to set the parentStatementPublicId as the import will remove and recreate the entitiy in the entityparents table
         raygEntities.forEach(raygEntity => {

--- a/test/unit/pages/data-entry-entity/MeasureValue.test.js
+++ b/test/unit/pages/data-entry-entity/MeasureValue.test.js
@@ -237,6 +237,14 @@ describe('pages/data-entry-entity/measure-value/MeasureValue', () => {
       expect(response).to.eql([entities[0], { publicId: 'pub-1', parentStatementPublicId: 'state-1', value: "hello again", date: "2020-10-06" }]);
     });
 
+    it('should set RAYG value to the next oldest entry when the date is changed for the latest entry', async () => {
+      const entities = [{  value: 'hello again', parentStatementPublicId: 'state-1', publicId: 'pub-2'  }];
+      const measuresEntities = [{ metricID: 'metric1', date: '05/10/2020', value: 2 }, { publicId: 'pub-2', metricID: 'metric1', date: '10/10/2020', value: 2 }];
+      const formData = { day: 3, month: 10, year: 2020 };
+      const response = await page.updateRaygRowForSingleMeasureWithNoFilter(entities, formData, measuresEntities, raygEntities, uniqMetricIds);
+      expect(response).to.eql([entities[0], { publicId: 'pub-1', parentStatementPublicId: 'state-1', value: 2, date: "2020-10-05" }]);
+    });
+
     it('should return input date when date is older than latest measure date', async () => {
       const formData = { day: 5, month: 10, year: 2020 };
       const response = await page.updateRaygRowForSingleMeasureWithNoFilter(entities, formData, measuresEntities, raygEntities, uniqMetricIds);


### PR DESCRIPTION
Updated the RAYG row when the latest entry (no filters and only item in the group) has it's date changed to a day in the past.