### PR TITLE
allow admin to produce a static export via admin panel

### DIFF
--- a/common/views/navigation.njk
+++ b/common/views/navigation.njk
@@ -42,7 +42,8 @@
     config.paths.admin.headlineMeasures,
     config.paths.admin.userManagementList,
     config.paths.admin.userManagementAuthentication,
-    config.paths.admin.createUser
+    config.paths.admin.createUser,
+    config.paths.admin.staticExports
     ]
 %}
 
@@ -167,6 +168,11 @@
     <li class="govuk-header__navigation-item child-item {{ 'govuk-header__navigation-item--active' if url in addEntitiesUrls }}">
         <a class="govuk-header__link child-nav" href="{{ config.paths.dataEntryEntity.bulkUpload }}">
         Entity data import
+        </a>
+    </li>
+    <li class="govuk-header__navigation-item child-item {{ 'govuk-header__navigation-item--active' if url == config.paths.admin.staticExports }}">
+        <a class="govuk-header__link child-nav" href="{{ config.paths.admin.staticExports }}">
+        Static Export
         </a>
     </li>
     </ul>

--- a/common/views/template.njk
+++ b/common/views/template.njk
@@ -12,7 +12,7 @@
 {% block head %}
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  {% if config.services.googleAnalytics.id %}
+  {% if config.services.googleAnalytics.id and not req.user.isStatic %}
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.services.googleAnalytics.id }}"></script>
     <script>

--- a/config/default.json
+++ b/config/default.json
@@ -4,7 +4,6 @@
   "cookie": {
     "expires": 3600000
   },
-  "temporaryDirectory": "./dist",
   "services": {
     "redis": {},
     "mysql": {},

--- a/config/default.json
+++ b/config/default.json
@@ -4,9 +4,11 @@
   "cookie": {
     "expires": 3600000
   },
+  "temporaryDirectory": "./dist",
   "services": {
     "redis": {},
     "mysql": {},
+    "s3": {},
     "tfa": {
       "name": "Transition Taskforce Dashboard"
     },
@@ -34,7 +36,8 @@
       "userManagementList": "/admin/manage-users-list",
       "userManagementAuthentication": "/admin/manage-users-authentication",
       "clearCache": "/admin/clear-cache",
-      "createUser": "/admin/create-user"
+      "createUser": "/admin/create-user",
+      "staticExports": "/admin/static-exports"
     },
     "allData": "/all-data",
     "filterExample": "/filter-example",

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,3 +8,4 @@ applications:
     services:
     - co-eu-transition-database
     - transition-dashboard-cache
+    - static-exports

--- a/migrations/23_static_export.js
+++ b/migrations/23_static_export.js
@@ -1,0 +1,51 @@
+const { services } = require('config');
+const logger = require('services/logger');
+const Sequelize = require('sequelize');
+
+const up = async (query) => {
+  await query.createTable('static_export', {
+    id: {
+      type: Sequelize.DataTypes.INTEGER,
+      primaryKey: true,
+      allowNull: false,
+      autoIncrement: true
+    },
+    status: {
+      type: Sequelize.DataTypes.ENUM('in_progress', 'complete', 'error'),
+      defaultValue: 'in_progress',
+      allowNull: false
+    },
+    url: Sequelize.DataTypes.STRING(2083),
+    error: Sequelize.DataTypes.TEXT,
+    created_at: {
+      type: Sequelize.DataTypes.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    },
+    updated_at: {
+      type: Sequelize.DataTypes.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP')
+    }
+  }, { charset: services.mysql.charset });
+};
+
+const down = async (query) => {
+  try {
+    await query.dropTable('static_export');
+  } catch (error) {
+    logger.error(`Error rolling back ${error}`);
+  }
+};
+
+module.exports = {
+  up: async (query) => {
+    try {
+      await up(query);
+    } catch (error) {
+      logger.error(`Error migrating ${error}`);
+      logger.error(`Rolling back changes`);
+      await down(query);
+      throw error;
+    }
+  },
+  down
+}

--- a/models/staticExport.js
+++ b/models/staticExport.js
@@ -1,0 +1,17 @@
+const { Model, STRING, ENUM, TEXT, INTEGER } = require('sequelize');
+const sequelize = require('services/sequelize');
+
+class StaticExport extends Model {}
+StaticExport.init({
+  id: {
+    type: INTEGER,
+    primaryKey: true,
+    allowNull: false,
+    autoIncrement: true
+  },
+  status: ENUM('in_progress', 'complete', 'error', 'queue'),
+  url: STRING(2083),
+  error: TEXT
+}, { sequelize, modelName: 'staticExport', tableName: 'static_export', createdAt: 'created_at', updatedAt: 'updated_at' });
+
+module.exports = StaticExport;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1938,6 +1938,53 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "aws-sdk": {
+      "version": "2.784.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.784.0.tgz",
+      "integrity": "sha512-+KBkqH7t/XE91Fqn8eyJeNIWsnhSWL8bSUqFD7TfE3FN07MTlC0nprGYp+2WfcYNz5i8Bus1vY2DHNVhtTImnw==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -5387,9 +5434,9 @@
       "integrity": "sha512-+vgXzFsh7wpLRGjFSDvDcA2zNA2wOxT6gGs/KUpkTjF1Uop9BerW/1W/YB1BMpeTEJoPlmrkA19+DS1fqJtL9Q=="
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "growl": {
       "version": "1.10.5",
@@ -6527,6 +6574,11 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
@@ -7643,6 +7695,16 @@
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+        },
+        "tar": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.12",
+            "inherits": "2"
+          }
         }
       }
     },
@@ -11479,13 +11541,58 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "tar": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
+      "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+        },
+        "fs-minipass": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
       }
     },
     "term-size": {
@@ -13092,6 +13199,22 @@
           "version": "2.17.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
           "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+        }
+      }
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@babel/core": "^7.11.1",
     "@babel/preset-env": "^7.11.0",
+    "aws-sdk": "^2.784.0",
     "babel-loader": "^8.1.0",
     "bcrypt": "^5.0.0",
     "body-parser": "^1.19.0",
@@ -81,6 +82,7 @@
     "sequelize": "^5.22.3",
     "speakeasy": "^2.0.0",
     "sprintf-js": "^1.1.2",
+    "tar": "^6.0.5",
     "umzug": "^2.3.0",
     "uuid": "^7.0.3",
     "webpack": "^4.44.1",

--- a/pages/admin/static-exports/StaticExports.html
+++ b/pages/admin/static-exports/StaticExports.html
@@ -1,0 +1,70 @@
+{% extends "template.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set staticExports = getStaticExports() | await %}
+
+{% block beforeContent %}
+  {% include "navigation.njk" %}
+  {% include "feedback.njk" %}
+{% endblock %}
+
+{% block pageTitle %}Static Exports{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+    {% if flash %}
+      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+        <h2 class="govuk-error-summary__title" id="error-summary-title">Error</h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            <li>
+              <a href="#headline-measures">{{ flash }}</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    {% endif %}
+
+    <h1 class="govuk-heading-l">Static Exports</h1>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">ID</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Status</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Error</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Last Updated</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter"></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        {% for staticExport in staticExports %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">{{ staticExport.id }}</td>
+            <td class="govuk-table__cell">{{ staticExport.status }}</td>
+            <td class="govuk-table__cell">{{ staticExport.error }}</td>
+            <td class="govuk-table__cell">{{ staticExport.updated_at | date ("DD/MM/YYYY HH:mm:ss", "x") }}</td>
+            <td class="govuk-table__cell">
+              {% if staticExport.status == 'complete' %}
+                <a class="govuk-link" href="{{ url }}/{{ getS3Id(staticExport.url) }}">
+                  Download
+                </a>
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    <form action='{{ url }}' method='POST'>
+      {{ govukButton({
+        text: "Generate Export",
+        type: "submit",
+        preventDoubleClick: true
+      }) }}
+    </form>
+   </div>
+  </div>
+{% endblock %}

--- a/pages/admin/static-exports/StaticExports.js
+++ b/pages/admin/static-exports/StaticExports.js
@@ -1,0 +1,192 @@
+const Page = require('core/pages/page');
+const flash = require('middleware/flash');
+const authentication = require('services/authentication');
+const StaticExport = require('models/staticExport');
+const { exec } = require('child_process');
+const tar = require('tar');
+const { v4: uuidv4 } = require("uuid");
+const config = require('config');
+const s3 = require('services/s3');
+const fs = require('fs');
+const pick = require('lodash/pick');
+const logger = require('services/logger');
+const moment = require('moment');
+const path = require('path');
+
+let s3Bucket = config.services.s3.exportStoreBucketName;
+if(config.services.vcapServices && config.services.vcapServices['aws-s3-bucket'].length) {
+  s3Bucket = config.services.vcapServices['aws-s3-bucket'][0].credentials.bucket_name;
+}
+
+class StaticExports extends Page {
+  get url() {
+    return config.paths.admin.staticExports;
+  }
+
+  get pathToBind() {
+    return `${this.url}/:fileName?`;
+  }
+
+  get middleware() {
+    return [
+      ...authentication.protect(['admin']),
+      flash
+    ];
+  }
+
+  get isDownloadExport() {
+    return this.req.params && this.req.params.fileName;
+  }
+
+  getS3Id(url) {
+    return url.split('/').pop();
+  }
+
+  downloadFile(req, res) {
+    s3.getObject({
+      Bucket: s3Bucket,
+      Key: req.params.fileName
+    })
+      .on('httpHeaders', (code, headers) => {
+        if (code < 300) {
+          // if not error set headers on response so browser knows its a file
+          res.set(pick(headers, 'content-type', 'content-length', 'last-modified'));
+        }
+      })
+      .createReadStream()
+      .on('error', error => {
+        logger.error(error);
+        res.flash('Error downloading file');
+        res.redirect(this.url);
+      })
+      .pipe(res);
+  }
+
+  async getRequest(req, res) {
+    if (this.isDownloadExport) {
+      return this.downloadFile(req, res);
+    }
+
+    super.getRequest(req, res);
+  }
+
+  async getStaticExports() {
+    return await StaticExport.findAll({
+      order: [['updated_at', 'DESC']]
+    });
+  }
+
+  async createStaticExport() {
+    return await StaticExport.create({ status: 'in_progress' });
+  }
+
+  generateStaticSiteExport(exportUid) {
+    return new Promise((resolve, reject) => {
+      const location = `${config.temporaryDirectory}/${exportUid}/export`;
+      exec(`node scripts/staticSiteGenerator.js --url ${config.serviceUrl} --dir ${location}`, async (error) => {
+        if (error) {
+          return reject(error);
+        }
+
+        resolve();
+      });
+    });
+  }
+
+  compressStaticSiteExport(exportUid) {
+    const exportLocation = path.resolve(`${config.temporaryDirectory}/${exportUid}`);
+    return tar.c({
+      gzip: true,
+      file: `${exportLocation}/export.tar.gz`,
+      cwd: exportLocation,
+    }, ['export']);
+  }
+
+  async uploadCompressedStaticSiteExportToS3(exportUid) {
+    const fileName = `${exportUid}.tar.gz`;
+    const file = fs.readFileSync(`${config.temporaryDirectory}/${exportUid}/export.tar.gz`);
+
+    const params = {
+      Bucket: s3Bucket,
+      Key: fileName,
+      Body: file
+    };
+
+    return new Promise((resolve, reject) => {
+      s3.upload(params, (err, data) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve(data.Location);
+      });
+    });
+  }
+
+  async removeTemporaryDirectory(exportUid) {
+    return new Promise((resolve, reject) => {
+      fs.rmdir(`${config.temporaryDirectory}/${exportUid}`, { recursive: true }, (err) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve();
+      });
+    });
+  }
+
+  async doStaticExport(staticExport) {
+    try {
+      const exportUid = uuidv4();
+
+      await this.generateStaticSiteExport(exportUid);
+      await this.compressStaticSiteExport(exportUid);
+      const url = await this.uploadCompressedStaticSiteExportToS3(exportUid);
+      await this.removeTemporaryDirectory(exportUid);
+
+      staticExport.status = 'complete';
+      staticExport.url = url;
+      await staticExport.save();
+    } catch (error) {
+      logger.error(error);
+      staticExport.status = 'error';
+      staticExport.error = error.message;
+      return await staticExport.save();
+    }
+  }
+
+  async getCurrentExport() {
+    const currentExport = await StaticExport.findOne({
+      where: { status: 'in_progress' }
+    });
+
+    if(!currentExport) {
+      return;
+    }
+
+    const tenMinutesAgo = moment().subtract(10, 'minutes');
+    const isStale = moment(currentExport.updated_at).isBefore(tenMinutesAgo);
+    if(isStale) {
+      currentExport.status = 'error';
+      currentExport.error = 'Timeout';
+      await currentExport.save();
+      return;
+    }
+
+    return currentExport;
+  }
+
+  async postRequest(req) {
+    const currentExport = await this.getCurrentExport();
+
+    if (currentExport) {
+      req.flash('Export still in progress');
+    } else {
+      const staticExport = await this.createStaticExport();
+      // dont wait for this, allow to run after responding to client
+      this.doStaticExport(staticExport);
+    }
+
+    this.next();
+  }
+}
+
+module.exports = StaticExports;

--- a/scripts/staticSiteGenerator.js
+++ b/scripts/staticSiteGenerator.js
@@ -59,13 +59,15 @@ const optionDefinitions = [
   { name: 'login-url', alias: 'l', type: String },
   { name: 'dir', alias: 'd', type: String },
   { name: 'email', alias: 'e', type: String },
-  { name: 'password', alias: 'p', type: String  }
+  { name: 'password', alias: 'p', type: String  },
+  { name: 'test', alias: 't', type: Boolean  } // add --test to only export first page
 ];
 const options = commandLineArgs(optionDefinitions);
 options.dir = path.resolve(options.dir) || path.resolve(__dirname, '..', 'dist');
 options.email = options.email || config.credentials.staticExportUser.email;
 options.password = options.password || config.credentials.staticExportUser.password;
 options.loginUrl = options.loginUrl || `${options.url}/login`;
+options.test = options.test || false;
 
 // Logs into a given url with params email and password and returns the cookies set by server
 const getAuthedCookie = async (url) => {
@@ -105,7 +107,7 @@ const exportStaticSite = async () => {
   await scrape({
     urls: [ options.url ],
     directory: options.dir,
-    recursive: true,
+    recursive: !options.test,
     maxDepth: 50,
     urlFilter: url => url.includes(options.url),
     request: {

--- a/services/s3.js
+++ b/services/s3.js
@@ -1,0 +1,19 @@
+const config = require('config');
+const AWS = require('aws-sdk');
+
+const options = {
+  apiVersion: '2006-03-01',
+  accessKeyId: config.services.s3.accessKey,
+  secretAccessKey: config.services.s3.secret,
+  region: config.services.s3.region
+};
+
+if(config.services.vcapServices && config.services.vcapServices['aws-s3-bucket'].length) {
+  options.accessKeyId = config.services.vcapServices['aws-s3-bucket'][0].credentials.aws_access_key_id;
+  options.secretAccessKey = config.services.vcapServices['aws-s3-bucket'][0].credentials.aws_secret_access_key;
+  options.region = config.services.vcapServices['aws-s3-bucket'][0].credentials.aws_region;
+}
+
+AWS.config.update({ region: options.region });
+
+module.exports = new AWS.S3(options);

--- a/test/unit/models/staticExport.test.js
+++ b/test/unit/models/staticExport.test.js
@@ -1,0 +1,19 @@
+const { expect } = require('test/unit/util/chai');
+const StaticExport = require('models/staticExport');
+const { STRING, ENUM, TEXT, INTEGER } = require('sequelize');
+
+describe('models/staticExport', () => {
+  it('called StaticExport.init with the correct parameters', () => {
+    expect(StaticExport.init).to.have.been.calledWith({
+      id: {
+        type: INTEGER,
+        primaryKey: true,
+        allowNull: false,
+        autoIncrement: true
+      },
+      status: ENUM('in_progress', 'complete', 'error', 'queue'),
+      url: STRING(2083),
+      error: TEXT
+    });
+  });
+});

--- a/test/unit/pages/admin/StaticExport.test.js
+++ b/test/unit/pages/admin/StaticExport.test.js
@@ -11,6 +11,7 @@ const tar = require('tar');
 const path = require('path');
 const fs = require('fs');
 const moment = require('moment');
+const os = require('os');
 
 let StaticExports;
 let page = {};
@@ -189,7 +190,7 @@ describe('pages/admin/static-exports/StaticExports', () => {
 
       expect(error).to.be.undefined;
 
-      sinon.assert.calledWith(execStub, `node scripts/staticSiteGenerator.js --url ${config.serviceUrl} --dir ${config.temporaryDirectory}/${exportUid}/export`);
+      sinon.assert.calledWith(execStub, `node scripts/staticSiteGenerator.js --url ${config.serviceUrl} --dir ${os.tmpdir()}/${exportUid}/export`);
     });
 
     it('returns error if statuc site generator failes', async () => {
@@ -219,7 +220,7 @@ describe('pages/admin/static-exports/StaticExports', () => {
 
     it('zips up directory', async () => {
       const exportUid = 'some-id';
-      const exportLocation = path.resolve(`${config.temporaryDirectory}/${exportUid}`)
+      const exportLocation = path.resolve(`${os.tmpdir()}/${exportUid}`)
 
       page.compressStaticSiteExport(exportUid);
 
@@ -256,7 +257,7 @@ describe('pages/admin/static-exports/StaticExports', () => {
       expect(error).to.be.undefined;
       expect(location).to.eql('someLocation');
 
-      sinon.assert.calledWith(fs.readFileSync, `${config.temporaryDirectory}/${exportUid}/export.tar.gz`);
+      sinon.assert.calledWith(fs.readFileSync, `${os.tmpdir()}/${exportUid}/export.tar.gz`);
       sinon.assert.calledWith(s3.upload, {
         Bucket: config.services.s3.exportStoreBucketName,
         Key: `${exportUid}.tar.gz`,
@@ -300,7 +301,7 @@ describe('pages/admin/static-exports/StaticExports', () => {
       }
 
       expect(error).to.be.undefined;
-      sinon.assert.calledWith(fs.rmdir, `${config.temporaryDirectory}/${exportUid}`, { recursive: true });
+      sinon.assert.calledWith(fs.rmdir, `${os.tmpdir()}/${exportUid}`, { recursive: true });
     });
 
     it('returns error if not able to remove dir', async () => {

--- a/test/unit/pages/admin/StaticExport.test.js
+++ b/test/unit/pages/admin/StaticExport.test.js
@@ -1,0 +1,422 @@
+const { expect, sinon } = require('test/unit/util/chai');
+const { paths } = require('config');
+const flash = require('middleware/flash');
+const authentication = require('services/authentication');
+const StaticExport = require('models/staticExport');
+const s3 = require('services/s3');
+const config = require('config');
+const jwt = require('services/jwt');
+const proxyquire = require('proxyquire');
+const tar = require('tar');
+const path = require('path');
+const fs = require('fs');
+const moment = require('moment');
+
+let StaticExports;
+let page = {};
+let res = {};
+let req = {};
+let execStub;
+
+describe('pages/admin/static-exports/StaticExports', () => {
+  beforeEach(() => {
+    execStub = sinon.stub().callsArg(1);
+
+    StaticExports = proxyquire('pages/admin/static-exports/StaticExports', {
+      'child_process': { exec: execStub },
+      'uuid': { v4: sinon.stub().returns('some-id') }
+    });
+
+    res = { render: sinon.stub(), redirect: sinon.stub() };
+    req = { params: {}, flash: sinon.stub() };
+    page = new StaticExports('some path', req, res);
+    page.req = req;
+    page.res = res;
+
+    sinon.stub(authentication, 'protect').returns([]);
+    sinon.stub(jwt, 'restoreData').returns();
+  });
+
+  afterEach(() => {
+    authentication.protect.restore();
+    jwt.restoreData.restore();
+  });
+
+  describe('#url', () => {
+    it('returns correct url', () => {
+      expect(page.url).to.eql(paths.admin.staticExports);
+    });
+  });
+
+  describe('#pathToBind', () => {
+    it('adds fileName parameter', () => {
+      expect(page.pathToBind).to.eql(`${page.url}/:fileName?`);
+    });
+  });
+
+  describe('#middleware', () => {
+    it('only admins are aloud to access this page', () => {
+      expect(page.middleware).to.eql([
+        ...authentication.protect(['admin']),
+        flash
+      ]);
+
+      sinon.assert.calledWith(authentication.protect, ['admin']);
+    });
+  });
+
+  describe('#isDownloadExport', () => {
+    it('returns true if downloading export', () => {
+      page.req.params.fileName = true;
+      expect(page.isDownloadExport).to.be.ok;
+    });
+
+    it('returns false if downloading export', () => {
+      expect(page.isDownloadExport).to.not.be.ok;
+    });
+  });
+
+  describe('#getS3Id', () => {
+    it('gets s3 id from url', () => {
+      expect(page.getS3Id('some/id')).to.eql('id');
+    });
+  });
+
+  describe('#downloadFile', () => {
+    let getObjectMock = {};
+    let resMock = {};
+    let reqMock = {};
+
+    beforeEach(() => {
+      getObjectMock = {};
+      getObjectMock.on = sinon.stub().returns(getObjectMock);
+      getObjectMock.createReadStream = sinon.stub().returns(getObjectMock);
+      getObjectMock.pipe = sinon.stub().returns(getObjectMock);
+
+      sinon.stub(s3, 'getObject').returns(getObjectMock);
+
+      resMock = {
+        set: sinon.stub(),
+        flash: sinon.stub(),
+        redirect: sinon.stub()
+      };
+      reqMock = { params: { fileName: 'some-file.file' } };
+    });
+
+    afterEach(() => {
+      s3.getObject.restore();
+    });
+
+    it('successfully pipes file to response', () => {
+      const code = 200;
+      const headers = {
+        'content-type': 'content-type',
+        'content-length': 'content-length',
+        'last-modified': 'last-modified',
+      };
+      getObjectMock.on.withArgs(sinon.match('httpHeaders')).callsArgWith(1, code, headers).returns(getObjectMock);
+
+      page.downloadFile(reqMock, resMock);
+
+      sinon.assert.calledWith(s3.getObject, {
+        Bucket: config.services.s3.exportStoreBucketName,
+        Key: reqMock.params.fileName
+      });
+
+      sinon.assert.calledWith(getObjectMock.on, 'httpHeaders');
+      sinon.assert.calledWith(resMock.set, headers);
+      sinon.assert.calledOnce(getObjectMock.createReadStream);
+      sinon.assert.calledOnce(getObjectMock.pipe);
+    });
+
+    it('does not set headers if code 300 or more', () => {
+      const code = 300;
+      getObjectMock.on.withArgs(sinon.match('httpHeaders')).callsArgWith(1, code).returns(getObjectMock);
+
+      page.downloadFile(reqMock, resMock);
+
+      sinon.assert.notCalled(resMock.set);
+    });
+
+    it('sets flash on error', () => {
+      const error = new Error('some error');
+      getObjectMock.on.withArgs(sinon.match('error')).callsArgWith(1, error).returns(getObjectMock);
+
+      page.downloadFile(reqMock, resMock);
+
+      sinon.assert.calledWith(resMock.flash, 'Error downloading file');
+      sinon.assert.calledWith(resMock.redirect, page.url);
+    });
+  });
+
+  describe('#getRequest', () => {
+    beforeEach(() => {
+      page.downloadFile = sinon.stub();
+    });
+
+    it('calls downloadFile if in download mode', async () => {
+      page.req.params.fileName = true;
+
+      await page.getRequest(page.req, page.res);
+
+      sinon.assert.calledOnce(page.downloadFile);
+    });
+
+    it('calls downloadFile if in download mode', async () => {
+      await page.getRequest(page.req, page.res);
+
+      sinon.assert.notCalled(page.downloadFile);
+    });
+  });
+
+  describe('#getStaticExports', () => {
+    it('creates a static export', async () => {
+      await page.createStaticExport();
+      sinon.assert.calledWith(StaticExport.create, { status: 'in_progress' })
+    });
+  });
+
+  describe('#generateStaticSiteExport', () => {
+    it('executes the static site export script', async () => {
+      const exportUid = 'some-uid';
+
+      let error;
+      try {
+        await page.generateStaticSiteExport(exportUid);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).to.be.undefined;
+
+      sinon.assert.calledWith(execStub, `node scripts/staticSiteGenerator.js --url ${config.serviceUrl} --dir ${config.temporaryDirectory}/${exportUid}/export`);
+    });
+
+    it('returns error if statuc site generator failes', async () => {
+      const exportUid = 'some-uid';
+      const errorToRejectWith = new Error('some error');
+      execStub.callsArgWith(1, errorToRejectWith);
+
+      let error;
+      try {
+        await page.generateStaticSiteExport(exportUid);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).to.eql(errorToRejectWith);
+    });
+  });
+
+  describe('#compressStaticSiteExport', () => {
+    beforeEach(() => {
+      sinon.stub(tar, 'c');
+    });
+
+    afterEach(() => {
+      tar.c.restore();
+    });
+
+    it('zips up directory', async () => {
+      const exportUid = 'some-id';
+      const exportLocation = path.resolve(`${config.temporaryDirectory}/${exportUid}`)
+
+      page.compressStaticSiteExport(exportUid);
+
+      sinon.assert.calledWith(tar.c, {
+        gzip: true,
+        file: `${exportLocation}/export.tar.gz`,
+        cwd: exportLocation,
+      }, ['export'])
+    });
+  });
+
+  describe('#uploadCompressedStaticSiteExportToS3', () => {
+    beforeEach(() => {
+      sinon.stub(fs, 'readFileSync').returns('some-file');
+      sinon.stub(s3, 'upload').callsArgWith(1, undefined, { Location: 'someLocation' });
+    });
+
+    afterEach(() => {
+      s3.upload.restore();
+      fs.readFileSync.restore();
+    });
+
+    it('returns location on successfull upload', async () => {
+      const exportUid = 'some-id';
+
+      let error;
+      let location;
+      try {
+        location = await page.uploadCompressedStaticSiteExportToS3(exportUid);
+      } catch(err) {
+        error = err;
+      }
+
+      expect(error).to.be.undefined;
+      expect(location).to.eql('someLocation');
+
+      sinon.assert.calledWith(fs.readFileSync, `${config.temporaryDirectory}/${exportUid}/export.tar.gz`);
+      sinon.assert.calledWith(s3.upload, {
+        Bucket: config.services.s3.exportStoreBucketName,
+        Key: `${exportUid}.tar.gz`,
+        Body: 'some-file'
+      });
+    });
+
+    it('rejects with error if upload returns error', async () => {
+      const exportUid = 'some-id';
+      const someError = new Error('some error');
+      s3.upload.callsArgWith(1, someError);
+
+      let error;
+      try {
+        await page.uploadCompressedStaticSiteExportToS3(exportUid);
+      } catch(err) {
+        error = err;
+      }
+
+      expect(error).to.eql(someError);
+    });
+  });
+
+  describe('#removeTemporaryDirectory', () => {
+    beforeEach(() => {
+      sinon.stub(fs, 'rmdir').callsArg(2);
+    });
+
+    afterEach(() => {
+      fs.rmdir.restore();
+    });
+
+    it('successfully removes dir', async () => {
+      const exportUid = 'some-id';
+
+      let error;
+      try {
+        await page.removeTemporaryDirectory(exportUid);
+      } catch(err) {
+        error = err;
+      }
+
+      expect(error).to.be.undefined;
+      sinon.assert.calledWith(fs.rmdir, `${config.temporaryDirectory}/${exportUid}`, { recursive: true });
+    });
+
+    it('returns error if not able to remove dir', async () => {
+      const exportUid = 'some-id';
+      const someError = new Error('some error');
+      fs.rmdir.callsArgWith(2, someError);
+
+      let error;
+      try {
+        await page.removeTemporaryDirectory(exportUid);
+      } catch(err) {
+        error = err;
+      }
+
+      expect(error).to.eql(someError);
+    });
+  });
+
+  describe('#doStaticExport', () => {
+    const url = 'some-url';
+    let staticExportModel = {};
+
+    beforeEach(() => {
+      staticExportModel = {
+        save: sinon.stub()
+      };
+
+      sinon.stub(page, 'generateStaticSiteExport');
+      sinon.stub(page, 'compressStaticSiteExport');
+      sinon.stub(page, 'uploadCompressedStaticSiteExportToS3').returns(url);
+      sinon.stub(page, 'removeTemporaryDirectory');
+    });
+
+    it('orchastrates creating static export, compressing and uploading to s3', async () => {
+      await page.doStaticExport(staticExportModel);
+
+      expect(staticExportModel.url).to.eql(url);
+      expect(staticExportModel.status).to.eql('complete');
+      sinon.assert.calledOnce(staticExportModel.save);
+
+      sinon.assert.calledWith(page.generateStaticSiteExport, 'some-id');
+      sinon.assert.calledWith(page.compressStaticSiteExport, 'some-id');
+      sinon.assert.calledWith(page.uploadCompressedStaticSiteExportToS3, 'some-id');
+      sinon.assert.calledWith(page.removeTemporaryDirectory, 'some-id');
+    });
+
+    it('recoreds error against the static export model', async () => {
+      const error = new Error('some error');
+      page.generateStaticSiteExport.rejects(error);
+
+      await page.doStaticExport(staticExportModel);
+
+      expect(staticExportModel.error).to.eql(error.message);
+      expect(staticExportModel.status).to.eql('error');
+      sinon.assert.calledOnce(staticExportModel.save);
+    });
+  });
+
+  describe('#getCurrentExport', () => {
+    let currentExport = {};
+    beforeEach(() => {
+      currentExport = {
+        save: sinon.stub(),
+        updated_at: moment().format()
+      };
+      StaticExport.findOne.returns(currentExport);
+    });
+
+    it('gets the current export', async () => {
+      const returnedCurrentExport = await page.getCurrentExport();
+      expect(returnedCurrentExport).to.eql(currentExport);
+    });
+
+    it('sets export to expire if 10 minutes old', async () => {
+      currentExport.updated_at = moment().subtract(11, 'minutes').format();
+
+      const returnedCurrentExport = await page.getCurrentExport();
+
+      expect(returnedCurrentExport).to.be.undefined;
+
+      expect(currentExport.status).to.eql('error');
+      expect(currentExport.error).to.eql('Timeout');
+      sinon.assert.calledOnce(currentExport.save);
+    });
+
+    it('returns undefined if no export found', async () => {
+      StaticExport.findOne.returns();
+
+      const returnedCurrentExport = await page.getCurrentExport();
+
+      expect(returnedCurrentExport).to.be.undefined;
+    });
+  });
+
+  describe('#postRequest', () => {
+    beforeEach(() => {
+      sinon.stub(page, 'getCurrentExport');
+      sinon.stub(page, 'createStaticExport');
+      sinon.stub(page, 'doStaticExport');
+    });
+
+    it('sets error on flash if currentExport in progress', async () => {
+      page.getCurrentExport.returns(true);
+
+      await page.postRequest(page.req, page.res);
+
+      sinon.assert.calledWith(page.req.flash, 'Export still in progress');
+      sinon.assert.notCalled(page.createStaticExport);
+      sinon.assert.notCalled(page.doStaticExport);
+    });
+
+    it('starts export', async () => {
+      await page.postRequest(page.req, page.res);
+
+      sinon.assert.calledOnce(page.createStaticExport);
+      sinon.assert.calledOnce(page.doStaticExport);
+    });
+  });
+});

--- a/test/unit/services/s3.test.js
+++ b/test/unit/services/s3.test.js
@@ -1,0 +1,29 @@
+const { expect, sinon } = require('test/unit/util/chai');
+const proxyquire = require('proxyquire');
+const config = require('config');
+
+let s3 = {};
+let s3Stub = {};
+let s3Instance = { some: 'instance' };
+
+describe('services/s3', () => {
+  beforeEach(() => {
+    s3Stub = sinon.stub().returns(s3Instance);
+
+    s3 = proxyquire('services/s3', {
+      'aws-sdk': { S3: s3Stub }
+    });
+  });
+
+  it('should create an s3 instance', () => {
+    const options = {
+      apiVersion: '2006-03-01',
+      accessKeyId: config.services.s3.accessKey,
+      secretAccessKey: config.services.s3.secret,
+      region: config.services.s3.region
+    };
+    sinon.assert.calledWith(s3Stub, options);
+
+    expect(s3).to.eql(s3Instance);
+  });
+});


### PR DESCRIPTION
- add new admin page to allow admins to create, monitor and download static exports of the site
- add new table to track exports
- once static site is generated compress files and upload to s3
- hide ga tracking code if user has static role