### PR TITLE
fix mobile contrast issues 

### DIFF
--- a/common/scss/main.scss
+++ b/common/scss/main.scss
@@ -80,8 +80,6 @@
   background-color: black;
 }
 
-// li.govuk-header__navigation-item.logout-item
-
 .govuk-main-wrapper, .govuk-footer__meta {
   margin-left: 20px;
   margin-right: 20px;

--- a/common/scss/main.scss
+++ b/common/scss/main.scss
@@ -74,6 +74,14 @@
   font-weight: normal;
 }
 
+.govuk-header__link--service-name,
+.govuk-header__logotype-text,
+.logout-item {
+  background-color: black;
+}
+
+// li.govuk-header__navigation-item.logout-item
+
 .govuk-main-wrapper, .govuk-footer__meta {
   margin-left: 20px;
   margin-right: 20px;


### PR DESCRIPTION
Issue where on mobile, the logo, title and logout button had contrast accessibility errors. This was due to a hidden white background which is now changed to black.