### PR TITLE
Filtering by 0 to not include N/A values

### DIFF
--- a/helpers/utils.js
+++ b/helpers/utils.js
@@ -16,8 +16,6 @@ const removeNulls = (obj, maxDepth, currentDepth = -1) => {
         }
       } else if (obj[i] === null || obj[i] === undefined || (typeof obj[i] === "string" && !obj[i].length)) {
         obj.splice(i,1);
-      } else if (!isNaN(obj[i])) {
-        obj[i] = parseInt(obj[i]);
       }
     }
     if(!obj.length) {

--- a/test/unit/helpers/utils.test.js
+++ b/test/unit/helpers/utils.test.js
@@ -4,13 +4,18 @@ const { expect } = require('test/unit/util/chai');
 describe('helpers/utils', () => {
   describe('#removeNulls', () => {
     it('should remove empty items from arrays', () => {
-      const test = [1,'',undefined,[1, '', undefined],0];
-      expect(utils.removeNulls(test)).to.eql([1,[1],0]);
+      const test = [1,'',undefined,[1, '', undefined],0,'0'];
+      expect(utils.removeNulls(test)).to.eql([1,[1],0,'0']);
     });
 
     it('should remove empty items from objects', () => {
-      const test = { a: 'a', b: undefined, c: null, d: '', e: { a: 1, b: '' }, f: 0 };
-      expect(utils.removeNulls(test)).to.eql({ a: 'a', e: { a: 1 }, f: 0 });
+      const test = { a: 'a', b: undefined, c: null, d: '', e: { a: 1, b: '' }, f: 0, g:['0'] };
+      expect(utils.removeNulls(test)).to.eql({ a: 'a', e: { a: 1 }, f: 0, g:['0'] });
+    });
+
+    it('should remove empty items from object/array and keep number type in array as is', () => {
+      const test = { a: { b: '', c: '' }, d: ['0', '', 1] };
+      expect(utils.removeNulls(test)).to.eql({ d: ['0', 1] });
     });
 
     it('should remove empty items from mixed types', () => {

--- a/test/unit/helpers/utils.test.js
+++ b/test/unit/helpers/utils.test.js
@@ -25,7 +25,7 @@ describe('helpers/utils', () => {
           b: undefined,
           c: null,
           d: '',
-          e: ['a', ''],
+          e: ['a', '', 0, '0'],
           f: 0
         }, {
           a: undefined,
@@ -33,7 +33,7 @@ describe('helpers/utils', () => {
         }
       ];
 
-      expect(utils.removeNulls(test)).to.eql([{ a: 'a', e: ['a'], f: 0 }, { b: [1] }]);
+      expect(utils.removeNulls(test)).to.eql([{ a: 'a', e: ['a', 0, '0'], f: 0 }, { b: [1] }]);
     });
   });
 });


### PR DESCRIPTION
Fix - When filtering by 0, only those with 0 values will appear and not including the N/A values.

I've removed the piece of logic which checks if the value is a number and the parses it. This is because the number must be a string rather than an integer. 