### PR TITLE
bug fix to ensure uid is created correctly

### DIFF
--- a/models/milestone.js
+++ b/models/milestone.js
@@ -147,7 +147,7 @@ class Milestone extends Model {
       options.lock = transaction.LOCK
     }
 
-    const milestones = await sequelize.query(`SELECT uid FROM milestone WHERE project_uid='${projectUid}' ORDER BY LENGTH(uid) DESC, uid DESC LIMIT 1 FOR UPDATE`, options);
+    const milestones = await sequelize.query(`SELECT uid FROM milestone WHERE project_uid='${projectUid}' AND uid REGEXP '^[A-Za-z]+-[0-9]+-[0-9]+$' ORDER BY LENGTH(uid) DESC, uid DESC LIMIT 1 FOR UPDATE`, options);
 
     if(!milestones || !milestones.length) {
       return `${projectUid}-01`;

--- a/test/unit/models/milestone.test.js
+++ b/test/unit/models/milestone.test.js
@@ -206,7 +206,7 @@ describe('models/milestone', () => {
 
       const newId = await Milestone.getNextIDIncrement('MIL-01');
 
-      sinon.assert.calledWith(sequelize.query, "SELECT uid FROM milestone WHERE project_uid='MIL-01' ORDER BY LENGTH(uid) DESC, uid DESC LIMIT 1 FOR UPDATE", options);
+      sinon.assert.calledWith(sequelize.query, "SELECT uid FROM milestone WHERE project_uid='MIL-01' AND uid REGEXP '^[A-Za-z]+-[0-9]+-[0-9]+$' ORDER BY LENGTH(uid) DESC, uid DESC LIMIT 1 FOR UPDATE", options);
 
       expect(newId).to.eql('MIL-01-06');
     });
@@ -220,7 +220,7 @@ describe('models/milestone', () => {
 
       const newId = await Milestone.getNextIDIncrement('MIL-01');
 
-      sinon.assert.calledWith(sequelize.query, "SELECT uid FROM milestone WHERE project_uid='MIL-01' ORDER BY LENGTH(uid) DESC, uid DESC LIMIT 1 FOR UPDATE", options);
+      sinon.assert.calledWith(sequelize.query, "SELECT uid FROM milestone WHERE project_uid='MIL-01' AND uid REGEXP '^[A-Za-z]+-[0-9]+-[0-9]+$' ORDER BY LENGTH(uid) DESC, uid DESC LIMIT 1 FOR UPDATE", options);
 
       expect(newId).to.eql('MIL-01-01');
     });
@@ -238,7 +238,7 @@ describe('models/milestone', () => {
 
       const newId = await Milestone.getNextIDIncrement('MIL-01', options);
 
-      sinon.assert.calledWith(sequelize.query, "SELECT uid FROM milestone WHERE project_uid='MIL-01' ORDER BY LENGTH(uid) DESC, uid DESC LIMIT 1 FOR UPDATE", options);
+      sinon.assert.calledWith(sequelize.query, "SELECT uid FROM milestone WHERE project_uid='MIL-01' AND uid REGEXP '^[A-Za-z]+-[0-9]+-[0-9]+$' ORDER BY LENGTH(uid) DESC, uid DESC LIMIT 1 FOR UPDATE", options);
 
       expect(newId).to.eql('MIL-01-01');
     });


### PR DESCRIPTION
Added Regex to query (similar to that used in projects) to ensure only correctly format UID's are returned in the query to generate the next UID. 

The issue is currently affecting PROD data from being upload.