### PR TITLE
Show error if entity not found

### DIFF
--- a/pages/admin/entities/entity-delete/EntityDelete.html
+++ b/pages/admin/entities/entity-delete/EntityDelete.html
@@ -32,12 +32,14 @@
     {% set entity = getEntity() | await %}
   
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Delete entity</h1>
-    <h2 class="govuk-heading-m govuk-!-font-weight-regular"><strong>{{ entity.publicId }}</strong>: {{ entity.name }}</h2> 
 
     {% if entity.children | length %}
         {% include "admin/entities/entity-delete/partials/children-entity.njk" %}
-    {% else %}
+    {% elseif entity.publicId %}
         {% include "admin/entities/entity-delete/partials/delete-confirmation.njk" %}
+    {% else %}
+      <p class="govuk-body-l">Entity {{ req.params.publicId }} can not be found.</p>
+      <a href="{{ config.paths.admin.entityList }}" class="govuk-link govuk-body">Back to entities list</a>  
     {% endif %}
 
   {% endif %}

--- a/pages/admin/entities/entity-delete/EntityDelete.js
+++ b/pages/admin/entities/entity-delete/EntityDelete.js
@@ -49,15 +49,17 @@ class EntityDelete extends Page {
       }]
     });
 
-    entity.entityFieldEntries.map(entityfieldEntry => {
-      entity[entityfieldEntry.categoryField.name] = entityfieldEntry.value;
-    });
+    if (entity) {
+      entity.entityFieldEntries.map(entityfieldEntry => {
+        entity[entityfieldEntry.categoryField.name] = entityfieldEntry.value;
+      });
 
-    if (entity.children.length) {
-      for (const child of entity.children) {
-        child.entityFieldEntries.map(entityfieldEntry => {
-          child[entityfieldEntry.categoryField.name] = entityfieldEntry.value;
-        });
+      if (entity.children.length) {
+        for (const child of entity.children) {
+          child.entityFieldEntries.map(entityfieldEntry => {
+            child[entityfieldEntry.categoryField.name] = entityfieldEntry.value;
+          });
+        }
       }
     }
 

--- a/pages/admin/entities/entity-delete/partials/children-entity.njk
+++ b/pages/admin/entities/entity-delete/partials/children-entity.njk
@@ -1,3 +1,5 @@
+<h2 class="govuk-heading-m govuk-!-font-weight-regular"><strong>{{ entity.publicId }}</strong>: {{ entity.name }}</h2> 
+
 {{ govukWarningText({
     text: "This entity can’t be removed until their children have been remapped or deleted",
     iconFallbackText: "Warning"

--- a/pages/admin/entities/entity-delete/partials/delete-confirmation.njk
+++ b/pages/admin/entities/entity-delete/partials/delete-confirmation.njk
@@ -1,3 +1,5 @@
+<h2 class="govuk-heading-m govuk-!-font-weight-regular"><strong>{{ entity.publicId }}</strong>: {{ entity.name }}</h2> 
+
 {% if flash %}
 <div class="govuk-error-summary" aria-labelledby="error-summary-entity" role="alert" tabindex="-1" data-module="govuk-error-summary">
     <h2 class="govuk-error-summary__title" id="error-summary-entity">


### PR DESCRIPTION
Fixed an error where when a user clicks back button on the browser on a deleted entity, it will display that the entity is not found. 