### PR TITLE
Ddb 1790 - fixes for entity remap and permissions

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,7 +21,7 @@ app.set('trust proxy', true);
 
 helmet.attach(app);
 
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.urlencoded({ extended: true, parameterLimit: 5000 }));
 app.use(cookieParser());
 
 app.use(httpContext.middleware);

--- a/common/macros/entity-parents.njk
+++ b/common/macros/entity-parents.njk
@@ -1,0 +1,12 @@
+{% macro entityParents(entity) %}
+  {% if entity.parents | length %}
+    <div class="govuk-breadcrumbs govuk-!-margin-bottom-0">
+      <strong>Parents</strong>:
+      <ol class="govuk-breadcrumbs__list">
+        {% for entityParents in entity.parents %}
+          <li class=""><strong>{{ entityParents.publicId }}</strong>: {{ entityParents.name }}</li>
+        {% endfor %}
+      </ol>
+    </div>
+  {% endif %}
+{% endmacro %}

--- a/common/macros/entity-parents.njk
+++ b/common/macros/entity-parents.njk
@@ -1,7 +1,7 @@
 {% macro entityParents(entity) %}
   {% if entity.parents | length %}
     <div class="govuk-breadcrumbs govuk-!-margin-bottom-0">
-      <strong>Parents</strong>:
+      <strong>Parent(s)</strong>:
       <ol class="govuk-breadcrumbs__list">
         {% for entityParents in entity.parents %}
           <li class=""><strong>{{ entityParents.publicId }}</strong>: {{ entityParents.name }}</li>

--- a/common/macros/readiness-accordion.njk
+++ b/common/macros/readiness-accordion.njk
@@ -16,6 +16,7 @@
         {% set noChildren =  "no-children" if not item.meta.children %}
         {% set expanded =  "govuk-accordion__section--expanded" if item.expanded or active %}
 
+        {% if item.meta.children %}
         <div class="govuk-accordion__section govuk-accordion__section-{{ id }} {{ isLastExpandable }} {{ expanded }} {{ noChildren }}">
           <div class="govuk-accordion__section-header {{ color }} section-header-{{ item.level }}">
             <h2 class="govuk-accordion__section-heading">
@@ -39,12 +40,13 @@
               </div>
             {% endif %}
           </div>
-          {% if item.meta.children %}
-            <div id="{{ id }}-content-{{ loop.index }}" class="govuk-accordion__section-content" aria-labelledby="accordion-default-{{ id }}-heading-{{ loop.index }}">
-              {{ item.content | safe }}
-            </div>
-          {% endif %}
+          <div id="{{ id }}-content-{{ loop.index }}" class="govuk-accordion__section-content" aria-labelledby="accordion-default-{{ id }}-heading-{{ loop.index }}">
+            {{ item.content | safe }}
+          </div>
         </div>
+        {% else %}
+          {{ item.content | safe }}
+        {% endif %}
       {% endif %}
     {% endfor %}
   </div>
@@ -84,7 +86,7 @@
     {% elif item.children | length >= 1 and item.isLastExpandable %}
         {% set htmlContent = outcomeMeasuresContent(item.children) %}
     {% else %}
-        {% set htmlContent = '' %}
+        {% set htmlContent = outcomeMeasuresContent([item]) %}
     {% endif %}
     {% set outcomeMeasuresData = (outcomeMeasuresData.push ({
       meta: item,

--- a/helpers/entity.js
+++ b/helpers/entity.js
@@ -105,35 +105,14 @@ class EntityHelper {
     }
   }
 
-  async buildHierarchy(entity, parents = []) {
-    const entityCategoryId = entity.category.id;
+  async getParents(entity) {
+    const parents = []
     if(entity.parents && entity.parents.length) {
-      let selectedEntityParent = entity.parents[0];
-      
-      if (entity.parents.length > 1) {
-        // Entities can be nested and have multiple parents.  When we have multiple
-        // parents we want to find the item which will has the same category ID
-        for (const parent of entity.parents) {
-          const parentEntity = await this.getEntityData(parent.id);
-
-          if (parentEntity.category.id === entityCategoryId) {
-            selectedEntityParent = parent;
-          }  
-        }
-      }
-
-      const parent = await this.getEntityData(selectedEntityParent.id)
-      parents.unshift(parent);
-
-      if (parent.parents && parent.parents.length) {
-        await this.buildHierarchy(parent, parents)
-      }
+      for (const parent of entity.parents) {
+        const parentEntity = await this.getEntityData(parent.id); 
+        parents.push(parentEntity)
+      }  
     }
-  }
-
-  async getHierarchy(entity) {
-    const parents = [];
-    await this.buildHierarchy(entity, parents)
     return parents;
   }
 }

--- a/helpers/roleEntity.js
+++ b/helpers/roleEntity.js
@@ -17,13 +17,14 @@ const getEntitiesForRoleId = async(roleId) => {
   },{})
 }
 
-const doesEntityHasParentsPermission = (roleEntities, entitiesHeirarchy) => {
-  for(const entity of entitiesHeirarchy) {
+const doesEntityHasParentsPermission = async (roleEntities, entityParents, entityHelpers) => {
+  for(const entity of entityParents) {
     if (entity.id in roleEntities && roleEntities[entity.id].shouldCascade) {
       return true;
     }
+    entity.parents = await entityHelpers.getParents(entity);
     if (entity.parents && entity.parents.length > 0) {
-      return doesEntityHasParentsPermission(roleEntities, entity.parents)
+      return doesEntityHasParentsPermission(roleEntities, entity.parents, entityHelpers)
     }
   }
   

--- a/helpers/transitionReadinessData.js
+++ b/helpers/transitionReadinessData.js
@@ -699,9 +699,12 @@ const getThemesHierarchy = async (entitiesUserCanAccess) => {
 }
 
 const filterTopLevelOutcomeStatementsChildren = async(entities) => {
-  const statementCategory = await Category.findOne({
-    where: { name: 'Statement' }
+  const categories = await Category.findAll({
+    where: { name: ['Statement', 'Theme'] }
   });
+
+  const statementCategory = categories.find(category => category.name === 'Statement');
+  const themeCategory = categories.find(category => category.name === 'Theme');
 
   const filterChildren = (entities = []) => {
     for (var i = entities.length - 1; i >= 0; i--) {
@@ -731,7 +734,8 @@ const filterTopLevelOutcomeStatementsChildren = async(entities) => {
   return entities.filter(entity => {
     const hasChildren = entity.children && entity.children.length;
     const hasOnlyParentOrLess = entity.parents.length <= 1;
-    return hasChildren && hasOnlyParentOrLess;
+    const allParentAreThemes = entity.parents.every(parent => parent.categoryId === themeCategory.id)
+    return hasChildren && (hasOnlyParentOrLess || allParentAreThemes);
   });
 }
 

--- a/pages/admin/entities/entity-list/EntityList.html
+++ b/pages/admin/entities/entity-list/EntityList.html
@@ -1,5 +1,6 @@
 {% extends "template.njk" %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "entity-parents.njk" import entityParents %}
 
 {% set categories = getCategories() | await %}
 {% set entities = getEntitiesForCategory(categories[0].id) | await %}
@@ -33,16 +34,7 @@
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
               <strong>{{ entity.publicId }}</strong>: {{ entity.name }}
-              {% if entity.hierarchy | length %}
-                <div class="govuk-breadcrumbs govuk-!-margin-bottom-0">
-                  <strong>Hierarchy</strong>:
-                  <ol class="govuk-breadcrumbs__list">
-                    {% for entityHierarchyItem in entity.hierarchy %}
-                      <li class="govuk-breadcrumbs__list-item">{{ entityHierarchyItem.name }}</li>
-                    {% endfor %}
-                  </ol>
-                </div>
-              {% endif %}
+               {{ entityParents(entity) }}
             </td>
             <td class="govuk-table__cell text-align-right">
               <a href="{{ config.paths.admin.entityRemap }}/{{ entity.publicId }}" class="govuk-link govuk-!-margin-right-2">Remap</a>

--- a/pages/admin/entities/entity-list/EntityList.js
+++ b/pages/admin/entities/entity-list/EntityList.js
@@ -32,7 +32,7 @@ class EntityList extends Page {
     const entities = await entityHelper.entitiesInCategories([this.categorySelected || defaultCategoryId]);
 
     for(const entity of entities) {
-      entity.hierarchy = await entityHelper.getHierarchy(entity);
+      entity.parents = await entityHelper.getParents(entity);
     }
 
     return entities;

--- a/pages/admin/entities/entity-remap/EntityRemap.js
+++ b/pages/admin/entities/entity-remap/EntityRemap.js
@@ -86,7 +86,7 @@ class EntityRemap extends Page {
     const entities = await this.entityHelper.entitiesInCategories(categoryIds);
 
     for (const entity of entities) {
-      entity.hierarchy = await this.entityHelper.getHierarchy(entity);
+      entity.parents = await this.entityHelper.getParents(entity);
     }
 
     const entitiesByCategory = entities.reduce((acc, entity) => {

--- a/pages/admin/entities/entity-remap/partials/table.njk
+++ b/pages/admin/entities/entity-remap/partials/table.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "entity-parents.njk" import entityParents %}
 
 {% for categoryId, parentEntitied in parentEntitiesByCategory %}
   <table class="govuk-table govuk-!-margin-top-0">
@@ -15,16 +16,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           <strong>{{ entity.publicId }}</strong>: {{ entity.name }}
-          {% if entity.hierarchy | length %}
-          <div class="govuk-breadcrumbs govuk-!-margin-bottom-0">
-            <strong>Hierarchy</strong>:
-            <ol class="govuk-breadcrumbs__list">
-              {% for entityHierarchyItem in entity.hierarchy %}
-                <li class="govuk-breadcrumbs__list-item">{{ entityHierarchyItem.name }}</li>
-              {% endfor %}
-            </ol>
-          </div>
-        {% endif %}
+          {{ entityParents(entity) }}
         </td>
         <td class="govuk-table__cell">
         {{ govukCheckboxes({

--- a/pages/admin/permissions/Permissions.js
+++ b/pages/admin/permissions/Permissions.js
@@ -57,7 +57,7 @@ class Permissions extends Page {
         [parseInt(this.req.params.categoryId)]);
       const roleEntities = await getEntitiesForRoleId(this.req.params.roleId);
       for (const ec of entitiesForCategory) {
-        ec.hierarchy = await this.entityHelper.getHierarchy(ec);
+        ec.parents = await this.entityHelper.getParents(ec);
         if (ec.id in roleEntities) {
           ec.edit = roleEntities[ec.id].canEdit;
           ec.notSelected = false;
@@ -70,8 +70,7 @@ class Permissions extends Page {
           ec.shouldCascade = false;
         }
         ec.name = (ec.name) ? ec.name : 'Entity name is not set';
-        const hierarchy = await this.entityHelper.getHierarchy(ec);
-        ec.hasParentsPermission = doesEntityHasParentsPermission(roleEntities, hierarchy);
+        ec.hasParentsPermission = await doesEntityHasParentsPermission(roleEntities, ec.parents, this.entityHelper);
       }
       return entitiesForCategory;
     }

--- a/pages/admin/permissions/PermissionsTable.njk
+++ b/pages/admin/permissions/PermissionsTable.njk
@@ -1,95 +1,56 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "entity-parents.njk" import entityParents %}
-
-{% set tableRows = [] %}
-
-{% for entity in entities %}
-  {% from "govuk/components/radios/macro.njk" import govukRadios %}
-  {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
-
-  {% set entityName %}
-  <div>
-    <strong>{{ entity.publicId }}</strong>: {{ entity.name }}
-    {{ entityParents(entity) }}
-    <br>
-    <div><b>{{"Permissions are set by parent" if entity.hasParentsPermission}}</b></div>
-  </div>
-  {% endset -%}
-
-  {% set cascadeCheckBox %}
-        {{ govukCheckboxes({
-          idPrefix: entity.id,
-          name: entity.id,
-          classes: "govuk-checkboxes--small",
-          items: [
-            {
-              value: "cascade",
-              text: " ",
-              checked: entity.shouldCascade
-            }
-          ]
-        }) }}
-  {% endset -%}
-
-  {% set permissionRadio %}
-    {{ govukRadios({
-      classes: "govuk-radios--inline radio-option govuk-radios--small",
-      idPrefix: entity.id,
-      name: entity.id,
-      items: [
-        {
-          value: "view",
-          text: "view",
-          checked: entity.view
-        },
-        {
-          value: "edit",
-          text: "edit",
-          checked: entity.edit
-        },
-        {
-          value: "none",
-          text: "none",
-          checked: entity.notSelected
-        }
-      ]
-    }) }}
-  {% endset -%}
-
-  {% set rowItems = [] %}
-  {% set rowItems= (rowItems.push({
-        html: entityName,
-        classes: "category-name"
-      }, {
-        html: permissionRadio,
-        classes: "permissions-radio"
-      },
-      {
-        html: cascadeCheckBox,
-        classes: "cascade-checkbox"
-      }), rowItems) 
-  %}
-
-  {% set tableRows= (tableRows.push(rowItems), tableRows) %}
-{% endfor %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 <div id="permissions-table">
-  {{ govukTable({
-      firstCellIsHeader: true,
-      head: [
-        {
-          text: "Category",
-          classes: "header-first"
-        },
-        {
-          text: "Permissions",
-          classes: "header-middle"
-        },
-        {
-          text: "Cascade",
-          classes: "header-middle"
-        }
-      ],
-      rows: tableRows
-    }) }}
+  <table class="govuk-table govuk-!-margin-top-0">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header header-first">Category</th>
+      <th scope="col" class="govuk-table__header header-middle">Permissions</th>
+      <th scope="col" class="govuk-table__header header-middle">Cascade</th> 
+    </tr>
+    <tbody class="govuk-table__body">
+      {% for entity in entities %}
+        <tr class="govuk-table__row">
+          <th scope="col"  class="govuk-table__header category-name">
+              <div>
+              <strong>{{ entity.publicId }}</strong>: {{ entity.name }}
+              {{ entityParents(entity) }}
+              <br>
+              <div><b>{{"Permissions are set by parent" if entity.hasParentsPermission}}</b></div>
+            </div>
+          </th>
+          <td class="govuk-table__cell permissions-radio">
+            <div class="govuk-form-group">
+              <div class="govuk-radios govuk-radios--inline radio-option govuk-radios--small">
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="{{ entity.id }}" name="{{ entity.id }}" type="radio" value="view" {% if entity.view %}checked{% endif %}>
+                  <label class="govuk-label govuk-radios__label" for="{{ entity.id }}">view</label>
+                </div>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="{{ entity.id }}-edit" name="{{ entity.id }}" type="radio" value="edit" {% if entity.edit %}checked{% endif %}>
+                  <label class="govuk-label govuk-radios__label" for="{{ entity.id }}-edit">edit</label>
+                </div>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="{{ entity.id }}-none" name="{{ entity.id }}" type="radio" value="none" {% if entity.notSelected %}checked{% endif %}>
+                  <label class="govuk-label govuk-radios__label" for="{{ entity.id }}-none">none</label>
+                </div>
+              </div>
+            </div>
+          </td>
+          <td class="govuk-table__cell cascade-checkbox">
+            <div class="govuk-form-group">
+              <div class="govuk-checkboxes govuk-checkboxes--small">
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="{{ entity.id }}" name="{{ entity.id }}" type="checkbox" value="cascade" {% if entity.shouldCascade %}checked{% endif %}>
+                  <label class="govuk-label govuk-checkboxes__label" for="{{ entity.id }}"></label>
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
 </div>

--- a/pages/admin/permissions/PermissionsTable.njk
+++ b/pages/admin/permissions/PermissionsTable.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "entity-parents.njk" import entityParents %}
 
 {% set tableRows = [] %}
-
 
 {% for entity in entities %}
   {% from "govuk/components/radios/macro.njk" import govukRadios %}
@@ -10,16 +10,8 @@
   {% set entityName %}
   <div>
     <strong>{{ entity.publicId }}</strong>: {{ entity.name }}
-              {% if entity.hierarchy | length %}
-                <div class="govuk-breadcrumbs govuk-!-margin-bottom-0">
-                  <strong>Hierarchy</strong>:
-                  <ol class="govuk-breadcrumbs__list">
-                    {% for entityHierarchyItem in entity.hierarchy %}
-                      <li class="govuk-breadcrumbs__list-item">{{ entityHierarchyItem.name }}</li>
-                    {% endfor %}
-                  </ol>
-                </div>
-              {% endif %}
+    {{ entityParents(entity) }}
+    <br>
     <div><b>{{"Permissions are set by parent" if entity.hasParentsPermission}}</b></div>
   </div>
   {% endset -%}

--- a/pages/admin/rayg-values/RaygValues.js
+++ b/pages/admin/rayg-values/RaygValues.js
@@ -47,7 +47,7 @@ class RaygValues extends Page {
     return Object.keys(body).map(key => ({
       publicId: entities[key].publicId,
       categoryId: entities[key].categoryId,
-      raygStatus: body[key]
+      raygStatus: Array.isArray(body[key]) ? body[key][0] : body[key]
     }));
   }
 

--- a/test/unit/helpers/entity.test.js
+++ b/test/unit/helpers/entity.test.js
@@ -181,21 +181,6 @@ describe('helpers/entityHelper', () => {
     });
   });
 
-  // describe('#buildHierarchy', () => {
-  //   it('add entites which make up the entity hierarchy to the passed array', async () => {
-  //     const parents = [];
-  //     await entityHelper.buildHierarchy(entityMap[1], parents);
-  //     expect(parents).to.eql([entityMap[3], entityMap[2]]);
-  //   });
-  // });
-
-  // describe('#getHierarchy', () => {
-  //   it('returns the hierarchy for the selected entity, in reserve order', async () => {
-  //     const hierarchy = await entityHelper.getHierarchy(entityMap[1]);
-  //     expect(hierarchy).to.eql([entityMap[3], entityMap[2]]);
-  //   });
-  // });
-
   describe('#getParents', () => {
     it('returns the parents for the selected entity', async () => {
       const parents = await entityHelper.getParents(entityMap[1]);

--- a/test/unit/helpers/entity.test.js
+++ b/test/unit/helpers/entity.test.js
@@ -181,18 +181,25 @@ describe('helpers/entityHelper', () => {
     });
   });
 
-  describe('#buildHierarchy', () => {
-    it('add entites which make up the entity hierarchy to the passed array', async () => {
-      const parents = [];
-      await entityHelper.buildHierarchy(entityMap[1], parents);
-      expect(parents).to.eql([entityMap[3], entityMap[2]]);
-    });
-  });
+  // describe('#buildHierarchy', () => {
+  //   it('add entites which make up the entity hierarchy to the passed array', async () => {
+  //     const parents = [];
+  //     await entityHelper.buildHierarchy(entityMap[1], parents);
+  //     expect(parents).to.eql([entityMap[3], entityMap[2]]);
+  //   });
+  // });
 
-  describe('#getHierarchy', () => {
-    it('returns the hierarchy for the selected entity, in reserve order', async () => {
-      const hierarchy = await entityHelper.getHierarchy(entityMap[1]);
-      expect(hierarchy).to.eql([entityMap[3], entityMap[2]]);
+  // describe('#getHierarchy', () => {
+  //   it('returns the hierarchy for the selected entity, in reserve order', async () => {
+  //     const hierarchy = await entityHelper.getHierarchy(entityMap[1]);
+  //     expect(hierarchy).to.eql([entityMap[3], entityMap[2]]);
+  //   });
+  // });
+
+  describe('#getParents', () => {
+    it('returns the parents for the selected entity', async () => {
+      const parents = await entityHelper.getParents(entityMap[1]);
+      expect(parents).to.deep.eql([entityMap[2]]);
     });
   });
 

--- a/test/unit/helpers/roleEntity.test.js
+++ b/test/unit/helpers/roleEntity.test.js
@@ -20,7 +20,7 @@ describe('helpers/roleEntity', ()=>{
   });
 
   describe('doesEntityHasParentsPermission', ()=>{
-    it('should return true when parent has shouldCascade true', ()=>{
+    it('should return true when parent has shouldCascade true', async ()=>{
       const roleEntities = {
         '1':{
           shouldCascade: false
@@ -31,14 +31,18 @@ describe('helpers/roleEntity', ()=>{
       };
       const heierarcy = [{
         id: 5,
-        parents: [{ id:3 },{ id:2 }]
+        parents: [{ id:2 }]
       }];
+      
+      const entityHelpersStub = {
+        getParents: sinon.stub().resolves([{ id:2 }])
+      }
 
-      const hasParentsPermission = roleEntity.doesEntityHasParentsPermission(roleEntities,heierarcy);
+      const hasParentsPermission = await roleEntity.doesEntityHasParentsPermission(roleEntities,heierarcy, entityHelpersStub);
       expect(hasParentsPermission).to.be.true;
     });
 
-    it('should return false when parent has shouldCascade false', ()=>{
+    it('should return false when parent has shouldCascade false', async ()=>{
       const roleEntities = {
         '1':{
           shouldCascade: false
@@ -51,11 +55,15 @@ describe('helpers/roleEntity', ()=>{
         parents: [{ id:3 },{ id:2 }]
       }];
 
-      const hasParentsPermission = roleEntity.doesEntityHasParentsPermission(roleEntities,entities);
+      const entityHelpersStub = {
+        getParents: sinon.stub().resolves([])
+      }
+
+      const hasParentsPermission = await roleEntity.doesEntityHasParentsPermission(roleEntities,entities, entityHelpersStub);
       expect(hasParentsPermission).to.be.false;
     });
 
-    it('should return false when parent is not in roleEntities', ()=>{
+    it('should return false when parent is not in roleEntities', async ()=>{
       const roleEntities = {
         '1':{
           shouldCascade: false
@@ -67,8 +75,12 @@ describe('helpers/roleEntity', ()=>{
       const entities = [{
         parents: [{ id:3 },{ id:4 }]
       }];
+
+      const entityHelpersStub = {
+        getParents: sinon.stub().resolves([])
+      }
   
-      const hasParentsPermission = roleEntity.doesEntityHasParentsPermission(roleEntities,entities);
+      const hasParentsPermission = await roleEntity.doesEntityHasParentsPermission(roleEntities,entities, entityHelpersStub);
       expect(hasParentsPermission).to.be.false;
     });
   });

--- a/test/unit/pages/admin/EntityList.test.js
+++ b/test/unit/pages/admin/EntityList.test.js
@@ -87,7 +87,7 @@ describe("pages/admin/entities/entity-list/EntityList", () => {
 
     it("returns list of entities within a category along with their hierarchy", async () => {
       const response = await page.getEntitiesForCategory(2);
-      expect(response).to.eql([{ ...entityMap[2], hierarchy:[entityMap[3]] }])
+      expect(response).to.eql([{ ...entityMap[2], parents:[entityMap[3]] }])
     });
   });
 });


### PR DESCRIPTION
Fixes for entity remap and permissions:
Removed entity getHeirarachy and replace with getParents
Removed govuk macros on permissions page and replace with HTML to speed up the page render
fixes on theme pages to allow for multiple parents
increased bodyparse parameterLimit to allow for large permissions forms